### PR TITLE
Flatten payload

### DIFF
--- a/src/PushbulletMessage.php
+++ b/src/PushbulletMessage.php
@@ -144,11 +144,11 @@ class PushbulletMessage
     public function toArray()
     {
         $payload = [
-            'target' => $this->target->getTarget(),
             'type' => $this->type,
             'title' => $this->title,
             'body' => $this->message,
         ];
+        $payload = array_merge($payload,$this->target->getTarget());
 
         if ($this->type === static::TYPE_LINK) {
             $payload['url'] = $this->url;


### PR DESCRIPTION
Previous $payload format was not working, as documented in the Pushbullet API (https://docs.pushbullet.com/#create-push) there is no target field, target values are embbeded into root.