### PR TITLE
Ignore .idea (from JetBrains IDE's)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /vendor
 build
 composer.phar


### PR DESCRIPTION
Hello,

I always work with the JetBrains IDE PhpStorm, so I ignored the folder the IDE auto generates.